### PR TITLE
Separate code and config directories (#1)

### DIFF
--- a/OortArgs.py
+++ b/OortArgs.py
@@ -1,0 +1,70 @@
+#!python3
+# For Python 3.9.10 or later
+
+# ISC License
+# 
+# Copyright (c) 2022 OHSNAP
+# 
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# PERFORMANCE OF THIS SOFTWARE.
+
+
+###############
+# OortArgs.py #
+###############
+
+
+# STANDARD LIBRARIES
+import argparse
+import pathlib
+
+#
+# Public API
+#
+def OortArgs(programDescription: str = None):
+    global gOortArgParser
+    if gOortArgParser is None:
+        gOortArgParser = OortArgParser(programDescription)
+    return gOortArgParser
+
+
+#
+# Private API
+#
+gOortArgParser = None
+
+
+class OortArgParser:
+
+    parser = None
+    description = None
+    userArgs = None
+    
+    def __init__(self, programDescription: str = None):
+        if programDescription is not None:
+            self.description = programDescription
+        self.parser = argparse.ArgumentParser(description=self.description)
+        self.parser.add_argument("-v", "--verbosity", type=int, choices=[0, 1, 2], help="increase output verbosity")
+        self.parser.add_argument("-c", "--config-dir", type=pathlib.Path, help="path to oort-config (configuration files) directory")
+        self.parser.add_argument("-b", "--build-dir", type=pathlib.Path, help="path to oort-build (build products) directory")
+
+
+    def getArgs(self):
+        return self.parser.parse_args()
+
+
+    def get(self, key):
+        return getattr(self.getArgs(), key, None)
+
+    
+    def addArg(self, *args, **kwargs):
+        self.parser.add_argument(*args, **kwargs)

--- a/OortCommon.py
+++ b/OortCommon.py
@@ -24,6 +24,7 @@
 
 
 # INTERNAL LIBRARIES
+from OortArgs import OortArgs # must come first
 import machdep
 from machdep import machdepInit
 
@@ -48,18 +49,35 @@ import sys
 CSV_COMMENT_START =          "#"
 JSON_FILE_EXTENSION =        "json"
 
+### Configuration
 CONFIG_FILE_BASE_NAME =      "CONFIG"
 CONFIG_FILE_EXTENSION =      JSON_FILE_EXTENSION
 
-# Order of precedence:
-#   common -> realm -> role -> board -> host
+CONFIG_DIR_ENV_VAR_NAME =   "OORTCONFIGDIR"
+CONFIG_DIR_ALIAS_FILENAME = ".oortconfigpath"
+CONFIG_DIR_DOT_DIRNAME =    ".oortconfig"
+
+# Hardcoded config keys
+CONFIG_KEY_CONFIGPATH =         "config-file-path"
+CONFIG_KEY_EXECUTABLES_PATH =   "exec-dir"
+
+# User-settable config keys
+CONFIG_KEY_BUILD_ROOT_PATH =    "build-dir"
+CONFIG_KEY_NETBOOT_INTERFACE =  "netboot-interface"
+CONFIG_KEY_NETBOOT_HOST_IP =    "netboot-host-ip"
+CONFIG_KEY_NETBOOT_TARGET_IP =  "netboot-target-ip"
+CONFIG_KEY_NETBOOT_TARGET_MAC = "netboot-target-mac"
+
+### Domains
 DOMAIN_COMMON =              "common"
 DOMAIN_REALM =               "realm"
 DOMAIN_ROLE =                "role"
 DOMAIN_BOARD =               "board"
 DOMAIN_HOST =                "host"
+# Override hierarchy (last one wins):  common -> realm -> role -> board -> host
 DOMAINS = [DOMAIN_COMMON, DOMAIN_REALM, DOMAIN_ROLE, DOMAIN_BOARD, DOMAIN_HOST]
 
+### Hostmap file
 HOSTMAP_FILENAME =           "HOSTMAP.csv"
 HOSTMAP_FIELD_HOSTNAME =     "HOSTNAME"
 HOSTMAP_FIELD_REALM =        "REALM"
@@ -77,6 +95,7 @@ OSFLAVOR_CURRENT =           "current"
 OPENBSD_CURRENT_DIRNAME =    "snapshots"
 OPENBSD_PACKAGES_DIRNAME =   "packages"
 
+#### Boardmap file
 BOARDMAP_FILENAME =          "BOARDMAP.csv"
 BOARDMAP_FIELD_BOARDNAME =   "BOARDNAME"
 BOARDMAP_FIELD_SYSARCH =     "SYSARCH"
@@ -90,7 +109,8 @@ FLASHOPTIONS_FILENAME =      "_FLASHOPTIONS.json"
 
 OPENBSD_VERSION_FILENAME =   "RELEASE.txt"
 
-NETBOOT_CONFIG_DIRNAME =     "netboot"
+MACHDEP_DIRNAME =            "machdep"
+
 NETBOOT_APACHE_CONFIG_FILENAME = "apache.conf"
 NETBOOT_APACHE_PID_FILENAME = "apache.pid"
 NETBOOT_APACHE_ACCESS_LOG_FILENAME = "apache_access.log"
@@ -102,7 +122,6 @@ SHA256_READ_CHUNK_SIZE =     1024 * 1024 # read a file in chunks of 1MB when com
 # GLOBAL VARIABLES
 #
 # Persistent
-BUILD_ROOT_PATH = None
 gConfig = dict()
 gLatestOpenBsdStableVersion = None
 gVerboseLogs = True
@@ -323,32 +342,93 @@ def configValue(key):
     return gConfig.get(key)
 
 
+def locateConfigDirectory():    
+    # Determine where the oort-config directory lives. The path can be specified in several ways.
+    # Check in order of precedence:
+    # 1. The -c / --config-dir command line argument
+    # 2. The OORTCONFIGDIR environment variable
+    # 3. An .oortconfigpath file in user's home directory, containing the path to oort-config
+    # 4. An .oortconfig directory existing in the user's home directory containing the actual configuration
+    configDirPath = None
+
+    debug("All CLI args: %r" % OortArgs().getArgs())
+
+    # 1. The -c / --config-dir command line argument
+    configDirPath = OortArgs().get('config_dir')
+    debug("configDirPath = %r" % configDirPath)
+    if configDirPath is not None:
+        configDirPath = os.path.expanduser(configDirPath)
+        assert os.path.isdir(configDirPath), configDirPath + " is not a valid oort-config directory path"
+        return configDirPath
+
+    # 2. The OORTCONFIGDIR environment variable
+    configDirPath = os.getenv(CONFIG_DIR_ENV_VAR_NAME)
+    if configDirPath is not None:
+        configDirPath = os.path.expanduser(configDirPath)
+        assert os.path.isdir(configDirPath), "The environment variable " + CONFIG_DIR_ENV_VAR_NAME + " does not contain a valid directory path"
+        return configDirPath
+        
+    # 3. An .oortconfigpath file in user's home directory, containing the path to oort-config
+    configDirPathAlias = os.path.expanduser(os.path.join("~", CONFIG_DIR_ALIAS_FILENAME))
+    if os.path.isfile(configDirPathAlias):
+        with open(configDirPathAlias, "r") as configDirPathAliasFile:
+            configDirPath = configDirPathAliasFile.read().strip()
+    if configDirPath is not None:
+        assert os.path.isdir(configDirPath), "The file ~/" + CONFIG_DIR_ALIAS_FILENAME + " does not contain a valid directory path"
+        return configDirPath
+    
+    # 4. An .oortconfig directory existing in the user's home directory containing the actual configuration
+    configDirPath = os.path.expanduser(os.path.join("~", CONFIG_DIR_DOT_DIRNAME))
+    if os.path.isdir(configDirPath):
+        return configDirPath
+    
+    return configDirPath
+
+
 def readConfigFile():
     global gConfig
     
     # Read global config file
     configFilename = CONFIG_FILE_BASE_NAME + '.' + CONFIG_FILE_EXTENSION
-    debug("Reading global config file %s" % configFilename)
-    assert os.path.isfile(configFilename)
+    configFilePath = os.path.abspath(configFilename)
+    debug("Reading global config file %s" % configFilePath)
+    assert os.path.isfile(configFilename), "No readable configuration file at " + configFilePath
     gConfig = loadJSON(configFilename)
     
-    # Read host-local config file
+    # Read host-local config file, if present
+    localConfig = dict()
     localHostname = socket.gethostname()
     assert localHostname is not None and len(localHostname) > 0, "Couldn't determine local hostname"
     debug("Local hostname: %s" % localHostname)    
     configFilename = CONFIG_FILE_BASE_NAME + '-' + localHostname + '.' + CONFIG_FILE_EXTENSION
-    assert os.path.isfile(configFilename)
-    localConfig = loadJSON(configFilename)
+    if os.path.isfile(configFilename):
+        debug("Reading local config file %s" % os.path.abspath(configFilename))
+        localConfig = loadJSON(configFilename)
 
     # Merge configs
     gConfig = gConfig | localConfig
     debug("Merged config: %r" % gConfig)
 
-    # Set global settings from config file
-    global BUILD_ROOT_PATH
-    BUILD_ROOT_PATH = gConfig['objdir']
-    debug("BUILD_ROOT_PATH = %s" % BUILD_ROOT_PATH)
+    #
+    # Set other global settings from config file
+    #
     
+    ### Configuration file path
+    gConfig[CONFIG_KEY_CONFIGPATH] = configFilePath
+    
+    ### Build root path
+    # Can be specified in config file(s) and/or overridden by -b / --build-dir command line argument
+    buildRootPath = OortArgs().get('build_dir') or gConfig.get(CONFIG_KEY_BUILD_ROOT_PATH)
+    assert buildRootPath is not None, "You must specify a build products directory via the -b / --build-dir argument or in the OORT configuration file ('build-dir' key)"
+    buildRootPath = os.path.expanduser(buildRootPath)
+    gConfig[CONFIG_KEY_BUILD_ROOT_PATH] = buildRootPath
+    debug("Build Root Path:  %s" % buildRootPath)
+    
+    ### Executable path
+    execPath = os.path.realpath(os.path.abspath(os.path.dirname(__file__)))
+    gConfig[CONFIG_KEY_EXECUTABLES_PATH] = execPath
+    debug("Executable Path:  %s" % execPath)
+
 
 def validateHostmap():
     for d in gHostMap:
@@ -367,22 +447,28 @@ def validateHostmap():
         assert(     len(mac) > 0 and not containsWhitespace(mac) and isMAC(mac))
 
 
-def INITIALIZE_OPENBSD_PROVISIONING():
-    assert not platform.system() == 'Windows', "OpenBSD Provisioning is unsafe to run on Windows"
+def OortInit(argParser: OortArgs):
+    assert not platform.system() == 'Windows', "OORT is unsafe to run on Windows"
 
-    # Change current directory to location of script
-    os.chdir(os.path.dirname(__file__))
+    assertNotRootUser()
 
     # Identify what OS we are running on and initialize the OS-specific layer
     machdepInit()
     
+    # Find the oort-config directory
+    configDirPath = locateConfigDirectory()
+    assert os.path.isdir(configDirPath), "A valid oort-config directory could not be found. You must specify its absolute path via the -c/--config-dir argument, the " + CONFIG_DIR_ENV_VAR_NAME + " environment variable, or the ~/" + CONFIG_DIR_ALIAS_FILENAME + " file, or by storing your configuration in the ~/" + CONFIG_DIR_DOT_DIRNAME + " directory."
+
+    # Change current directory to oort-config directory
+    os.chdir(configDirPath)
+
     # Get user-configurable settings
     readConfigFile()
 
+    # Load host definitions
     print("Loading host definitions...")
     global gHostMap
     gHostMap = loadCSV(HOSTMAP_FILENAME)
     validateHostmap()
-
-
-INITIALIZE_OPENBSD_PROVISIONING()
+    
+    return argParser.getArgs()

--- a/OortCommon.py
+++ b/OortCommon.py
@@ -349,8 +349,6 @@ def locateConfigDirectory():
     # 2. The OORTCONFIGDIR environment variable
     # 3. An .oortconfigpath file in user's home directory, containing the path to oort-config
     # 4. An .oortconfig directory existing in the user's home directory containing the actual configuration
-    configDirPath = None
-
     debug("All CLI args: %r" % OortArgs().getArgs())
 
     # 1. The -c / --config-dir command line argument
@@ -382,7 +380,7 @@ def locateConfigDirectory():
     if os.path.isdir(configDirPath):
         return configDirPath
     
-    return configDirPath
+    return None
 
 
 def readConfigFile():
@@ -457,7 +455,7 @@ def OortInit(argParser: OortArgs):
     
     # Find the oort-config directory
     configDirPath = locateConfigDirectory()
-    assert os.path.isdir(configDirPath), "A valid oort-config directory could not be found. You must specify its absolute path via the -c/--config-dir argument, the " + CONFIG_DIR_ENV_VAR_NAME + " environment variable, or the ~/" + CONFIG_DIR_ALIAS_FILENAME + " file, or by storing your configuration in the ~/" + CONFIG_DIR_DOT_DIRNAME + " directory."
+    assert configDirPath and os.path.isdir(configDirPath), "A valid oort-config directory could not be found. You must specify its absolute path via the -c/--config-dir argument, the " + CONFIG_DIR_ENV_VAR_NAME + " environment variable, or the ~/" + CONFIG_DIR_ALIAS_FILENAME + " file, or by storing your configuration in the ~/" + CONFIG_DIR_DOT_DIRNAME + " directory."
 
     # Change current directory to oort-config directory
     os.chdir(configDirPath)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ INSTRUCTIONS GO HERE
 
 - `createSiteFiles`: There is no way to edit or append a file instead of overriding it wholesale
 - `autoinstall`: Need a setup script to download and compile `dnsmasq` into `machdep` directory
+- Need a `setup.py` command for guiding the user through initial setup
+- Need a standalone `oort` command for invoking main features
 - ALL: Linux host OS is planned but not yet supported
 - ALL: Windows host OS is specifically unsupported and is unlikely to be supported without external code contributions
 - ALL: The code will likely need a total rewrite to make it cleaner, more uniform, and more Pythonic

--- a/flashInstall.py
+++ b/flashInstall.py
@@ -22,8 +22,11 @@
 # flashInstall.py #
 ###################
 
+PROGRAM_DESCRIPTION = 'Erase a removable storage device and write the OpenBSD installer image onto it.'
+
 
 # INTERNAL LIBRARIES
+from OortArgs import OortArgs # must come first
 from OortCommon import *
 import masterDisks
 from masterDisks import generateMasteringImageForHostname
@@ -210,13 +213,11 @@ def eraseAndFlashNode(nodeName, diskManifest):
 
 
 def main(argv):
-    assertNotRootUser()
-
-    parser = argparse.ArgumentParser(description='Erase a removable storage device and write the OpenBSD installer image onto it.')
-    parser.add_argument("hostname", help="Name of host for which to create the installer")
-    parser.add_argument("-y", "--yes", action="store_true", help="Auto-accept confirmations to execute system commands")
-    parser.add_argument("-v", "--verbosity", type=int, choices=[0, 1, 2], help="increase output verbosity")
-    args = parser.parse_args()
+    global PROGRAM_DESCRIPTION
+    argParser = OortArgs(PROGRAM_DESCRIPTION)
+    argParser.addArg("hostname", help="Name of host for which to create the installer disk")
+    argParser.addArg("-y", "--yes", action="store_true", help="Auto-accept confirmations to execute system commands")
+    args = OortInit(argParser)
 
     hostname = args.hostname
     global gAutoAcceptYes

--- a/machdep.py
+++ b/machdep.py
@@ -43,6 +43,9 @@ def machdep_run_command_as_superuser(cmd):
 def machdep_mounted_removable_devices():
     return machdep().mounted_removable_devices()
 
+def machdep_platform():
+    return os.uname().sysname
+    
 
 #
 # PRIVATE API

--- a/masterDisks.py
+++ b/masterDisks.py
@@ -22,9 +22,13 @@
 # masterDisks.py #
 ##################
 
+PROGRAM_DESCRIPTION = 'Generate installation boot disk and set packages disk for one or more hosts'
+
 
 # INTERNAL LIBRARIES
+from OortArgs import OortArgs # must come first
 from OortCommon import *
+import OortCommon
 from createSiteFiles import generateSitePackage, autoinstallConfigurationRootPathForHost
 
 
@@ -446,7 +450,7 @@ def downloadImagesForHost(hostdef):
     openBSDVersionString = openBSDVersion(hostdef)
     
     # Create download directories
-    outputDirs = prepareDownloadDirectories(hostdef, BUILD_ROOT_PATH)
+    outputDirs = prepareDownloadDirectories(hostdef, configValue(CONFIG_KEY_BUILD_ROOT_PATH))
     debug("Download directories: %r" % outputDirs)
     
     # Determine URL for downloading install sets based on OpenBSD version and architecture
@@ -563,7 +567,7 @@ def stageImagesForHost(hostdef, downloadDirPaths):
     boardName = hostdef[HOSTMAP_FIELD_BOARD]
     
     # Create staging directories
-    outputDirs = prepareStagingDirectories(hostdef, BUILD_ROOT_PATH)
+    outputDirs = prepareStagingDirectories(hostdef, configValue(CONFIG_KEY_BUILD_ROOT_PATH))
     debug("Staging directories: %r" % outputDirs)
 
     #
@@ -670,18 +674,16 @@ def generateMasteringImageForHostname(hostname):
 
 
 def main(argv):
-    assertNotRootUser()
-    
-    hostnames = None
-    completedCount = 0
-    
-    # Check arg list
-    if len(sys.argv) > 2:
-        usage()
-    elif len(sys.argv) == 2:
-        hostnames = [ sys.argv[1] ]
+    global PROGRAM_DESCRIPTION
+    argParser = OortArgs(PROGRAM_DESCRIPTION)
+    argParser.addArg("hostnames", nargs='*', help="Name(s) of host(s) for which to generate mastering images")
+    args = OortInit(argParser)
 
-    if hostnames == None:
+    hostnames = args.hostnames
+
+    completedCount = 0
+
+    if hostnames == None or len(hostnames) == 0:
         hostnames = list()
         for hostdef in OortCommon.gHostMap:
             if not hostdef[HOSTMAP_FIELD_ROLE] == HOST_ROLE_VIRTUAL: # skip virtual entries


### PR DESCRIPTION
Refactored code to allow specifying an `oort-config` and an `oort-build` directory, separate from the `oort-code` directory.

The `oort-config` path must be specified in (at least) one of four ways. In search order, these are:

1. The `-c` / `--config-dir` command line argument.
2. The `OORTCONFIGDIR` environment variable.
3. An `.oortconfigpath` file, inside the user's home directory, which contains the path to the `oort-config` directory.
4. An `.oortconfig/` directory, inside the user's home directory, which contains the actual configuration itself (i.e., `~/.oortconfig` is `oort-config`).

The `oort-build` path must be specified in `CONFIG.json`  via the `build-dir` key and/or overridden by the `-b` / `--build-dir` command line argument.

As part of this change, a small command line argument parser class (`OortArgs`) was added in order to allow for parsing both a global list of arguments across all the tools and a tool-specific additional list of arguments. All four tools were updated to adopt this paradigm.

Future changes will expose more available arguments (ideally bringing 1:1 parity between CLI and `CONFIG.json`). The `configValue()` common method is the API that all tools should use to retrieve configuration values, whether specified by the user or generated by the program itself.