### PR TITLE
Safer subprocess execution (#5)

### DIFF
--- a/autoinstall.py
+++ b/autoinstall.py
@@ -244,7 +244,7 @@ wait
         
         if shouldSpawn:
             print("Spinning up background tasks...")
-            machdep_run_command_as_superuser(spawnScriptPath)
+            machdep_run_command_as_superuser([ spawnScriptPath ])
 
 
 def main(argv):

--- a/machdep.py
+++ b/machdep.py
@@ -37,11 +37,23 @@ if TYPE_CHECKING:
 def machdepInit():
     machdep()
 
-def machdep_run_command_as_superuser(cmd):
-    return machdep().run_command_as_superuser(cmd)
+def machdep_run_command(cmd: list):
+    return machdep().run_command(cmd)
+
+def machdep_run_command_as_superuser(cmd: list):
+    return machdep().run_command(cmd, superuser=True)
 
 def machdep_mounted_removable_devices():
     return machdep().mounted_removable_devices()
+
+def machdep_unmount_disk(nodeName):
+    return machdep().unmount_disk(nodeName)
+
+def machdep_erase_disk(nodeName):
+    return machdep().erase_disk(nodeName)
+
+def machdep_validate_disk_node(nodeName):
+    return machdep().validate_disk_node(nodeName)
 
 
 #
@@ -57,10 +69,19 @@ gMachdep = None
 
 class Machdep(object):
 
-    def run_command_as_superuser(self, cmd):
+    def run_command(self, cmd: list, superuser = False):
         raise NotImplementedError()
 
     def mounted_removable_devices(self):
+        raise NotImplementedError()
+
+    def unmount_disk(self, nodeName):
+        raise NotImplementedError()
+
+    def erase_disk(self, nodeName):
+        raise NotImplementedError()
+
+    def validate_disk_node(self, nodeName):
         raise NotImplementedError()
 
     

--- a/machdep_openbsd.py
+++ b/machdep_openbsd.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 # STANDARD LIBRARIES
 import os
+import subprocess
 
 #
 # Try to avoid import recursion
@@ -39,15 +40,23 @@ if TYPE_CHECKING:
 #
 class OpenBSD:
     
+    #
+    # Public API
+    #
     def __init__(self: Machdep):
         pass
         
-    def run_command_as_superuser(self, cmd):
+
+    def run_command(self, cmd: list, superuser = False):
         exitCode = 0
 
-        rawSystemCommand = "doas " + cmd
-        debug("rawSystemCommand = %s" % rawSystemCommand)
+        from OortCommon import debug
 
-        exitCode = os.system(rawSystemCommand)
+        debug("run_command(cmd = %r, superuser = %r)" % (cmd, superuser))
+
+        if superuser:
+            cmd.insert(0, 'doas')
+
+        output = subprocess.run(cmd, capture_output=True)
     
-        return exitCode
+        return output.returncode


### PR DESCRIPTION
- Replace unsafe `os.system()` with safer `subprocess.run()` calls
- Move more OS-specific subprocess invocations (`unmountDisk()`, `eraseDisk()`, `validateNode()`) into `machdep_*.py`
- Change Darwin implementation of privileged execution from `osascript` to `sudo`

Notably, this change removes the second confirmation prompt prior to erasing a disk in `flashInstall.py` (the command line invocation confirmation). This makes the default flow that much less annoying, at the expense of possibly allowing the erase command to run with unintended arguments if the user wasn't paying close attention. We may want to bring back the prompt.