### PR TITLE
Rock64 board support (#13)

### DIFF
--- a/masterDisks.py
+++ b/masterDisks.py
@@ -276,6 +276,7 @@ def bootloaderPackagesInfoForHost(hostdef):
 
         # In general, each board may specify different bootloader files
         if  boardName == "rockpi4" or \
+            boardName == "rock64" or \
             boardName == "rockpro64" or \
             boardName == "pinebookpro":
             bootloaderPackagesInfo['u-boot']['tarContentsExtractBoardChildPaths'] = [


### PR DESCRIPTION
Support bootloader for https://www.pine64.org/devices/single-board-computers/rock64/

_(Yes, we should find a cleaner way of specifying board-specific configuration **outside** of the code...)_