### PR TITLE
Template variables for install.conf (#12)

### DIFF
--- a/createSiteFiles.py
+++ b/createSiteFiles.py
@@ -68,9 +68,11 @@ AUTOGEN_FILENAME_SITE_INSTALL_APPEND =  "_AUTOGEN_install.site"
 AUTOGEN_FILENAME_AUTOINSTALL =          "_AUTOGEN_" + AUTOINSTALL_FILENAME
 AUTOGEN_FILEPATTERN_AUTODISKLABEL =     "_AUTOGEN_" + AUTODISKLABEL_FILENAME_PTN
 
+AUTOINSTALL_VAR_HOSTNAME =        "__OORT_TEMPLATE_HOSTNAME__"
+AUTOINSTALL_VAR_NETBOOT_HOST_IP = "__OORT_TEMPLATE_NETBOOT_HOST_IP__"
+AUTOINSTALL_VAR_OPENBSD_VERSION = "__OORT_TEMPLATE_OPENBSD_SHORTVERSION__"
+
 TMP_DIR_PREFIX = "network.ohsnap.oort.sitegen_"
-
-
 
 
 #
@@ -179,7 +181,14 @@ def processAutogenFile(sourcePath, destPath, domain, hostdef):
     elif sourceName == AUTOGEN_FILENAME_AUTOINSTALL:
         # The autoinstall file doesn't actually go into the site package, so we need to manually move it up into the host output parent directory
         destPath = os.path.join(autoinstallConfigurationRootPathForHost(hostdef), AUTOINSTALL_FILENAME)
-        shutil.copyfile(sourcePath, destPath)
+        # Copy to the destination, performing template variable substitution along the way
+        varSubs = { AUTOINSTALL_VAR_HOSTNAME:        hostdef[HOSTMAP_FIELD_HOSTNAME],
+                    AUTOINSTALL_VAR_NETBOOT_HOST_IP: configValue(CONFIG_KEY_NETBOOT_HOST_IP),
+                    AUTOINSTALL_VAR_OPENBSD_VERSION: openBSDVersion(hostdef) }
+        with open(sourcePath, 'r') as srcAutoinstallConf:
+            with open(destPath, 'w') as dstAutoinstallConf:
+                dstAutoinstallConf.write(replaceVariablesInString(srcAutoinstallConf.read(), varSubs))
+        
 
     # autodisklabel file(s) for autoinstallation
     elif autodisklabelNameMatch := re.match(AUTOGEN_FILEPATTERN_AUTODISKLABEL, sourceName):


### PR DESCRIPTION
Provide template strings that users can insert into the autoinstall configuration file (`_AUTOGEN_install.conf`) which will be substituted with variables during `createSiteFiles.py`.

Currently defined variables:
- `__OORT_TEMPLATE_HOSTNAME__`: Target machine's hostname
- `__OORT_TEMPLATE_OPENBSD_SHORTVERSION__ `: OpenBSD short version string
- `__OORT_TEMPLATE_NETBOOT_HOST_IP__ `: Netboot host IP address

A specific use case is to programmatically update the `site.tgz` version number that's used for the `SHA256.sig` hash exception list in `install.conf`. This change prevents the installation from dying when the OpenBSD version number gets bumped and the installer consequently skips the "it's ok to ignore SHA256 mismatches on this one file" because the (previously) hardcoded filename is now out of date.

Later on we might want to generalize the template mechanism to allow (1) generic substitution of any configuration variable and (2) variable substitution in all (or most) user-defined files, not just `install.conf`.