### PR TITLE
Add --list-hosts option (#18)

### DIFF
--- a/OortArgs.py
+++ b/OortArgs.py
@@ -56,6 +56,10 @@ class OortArgParser:
         self.parser.add_argument("-v", "--verbosity", type=int, choices=[0, 1, 2], help="increase output verbosity")
         self.parser.add_argument("-c", "--config-dir", type=pathlib.Path, help="path to oort-config (configuration files) directory")
         self.parser.add_argument("-b", "--build-dir", type=pathlib.Path, help="path to oort-build (build products) directory")
+        
+        operationGroup = self.parser.add_mutually_exclusive_group()
+        operationGroup.add_argument("-d", "--default-operation", action='store_true', default=False, help="run this tool normally (this is the default)")
+        operationGroup.add_argument("-l", "--list-hosts", action='store_true', default=False, help="instead of running this tool, list all defined hostnames and exit")
 
 
     def getArgs(self):

--- a/OortCommon.py
+++ b/OortCommon.py
@@ -445,6 +445,22 @@ def validateHostmap():
         assert(     len(mac) > 0 and not containsWhitespace(mac) and isMAC(mac))
 
 
+def getOperationalModeFromParsedArgs(args: dict):
+    if args.list_hosts is True:
+        return "list_hosts"
+    
+    return "default"
+
+
+def listHostsAndExit():
+    print("Available hosts:")
+    
+    for host in sorted(gHostMap, key=lambda x: x[HOSTMAP_FIELD_HOSTNAME]):
+        print("    %s" % host[HOSTMAP_FIELD_HOSTNAME])
+    
+    exit()
+
+
 def OortInit(argParser: OortArgs):
     assert not platform.system() == 'Windows', "OORT is unsafe to run on Windows"
 
@@ -469,4 +485,13 @@ def OortInit(argParser: OortArgs):
     gHostMap = loadCSV(HOSTMAP_FILENAME)
     validateHostmap()
     
-    return argParser.getArgs()
+    userOptions = argParser.getArgs()
+    
+    # Determine if we should run the tool as normal or perform another action instead
+    mode = getOperationalModeFromParsedArgs(userOptions)    
+    if mode == "default":
+        pass
+    elif mode == "list_hosts":
+        listHostsAndExit()
+    
+    return userOptions


### PR DESCRIPTION
Add a global CLI option (`-l` / `--list-hosts`) to print a sorted list of all defined hosts in `HOSTMAP.csv` and exit, instead of running the specified tool's normal operation. This also creates a `-d` / `--default-operation` argument, which is normally never specified.