### PR TITLE
Skip printing virtual hosts when listing available hostnames (#18)

### DIFF
--- a/OortCommon.py
+++ b/OortCommon.py
@@ -456,7 +456,8 @@ def listHostsAndExit():
     print("Available hosts:")
     
     for host in sorted(gHostMap, key=lambda x: x[HOSTMAP_FIELD_HOSTNAME]):
-        print("    %s" % host[HOSTMAP_FIELD_HOSTNAME])
+        if host[HOSTMAP_FIELD_ROLE] != HOST_ROLE_VIRTUAL:
+            print("    %s" % host[HOSTMAP_FIELD_HOSTNAME])
     
     exit()
 


### PR DESCRIPTION
When invoking a tool with the `--list-hosts` option, avoid including hosts with the `VIRTUAL` boardname because they aren't actual deployable hosts.

Signed-off-by: pion <87685723+nbpion@users.noreply.github.com>