### PR TITLE
Restore or override /etc/installurl after autoinstall (#29)

### DIFF
--- a/OortCommon.py
+++ b/OortCommon.py
@@ -136,6 +136,7 @@ BOARDMAP_FIELD_FLASH_OPTIONS = "flashOptions" # not stored in BOARDMAP.csv; see 
 
 #### Host options file
 HOSTOPTIONS_KEY_DOMAIN_NAME = "domain-name"
+HOSTOPTIONS_KEY_INSTALLURL  = "etc-install-url"
 
 
 FLASHOPTIONS_FILENAME =      "_FLASHOPTIONS.json"


### PR DESCRIPTION
Overwrite `/etc/installurl` in `install.site` with either the `etc-install-url` host option if present or the default value of `https://cdn.openbsd.org/pub/OpenBSD`, which will fix the bogus URL generated by `autoinstall(8)` due to us hosting our own temporary package server in `autoinstall.py`.

Signed-off-by: pion <87685723+nbpion@users.noreply.github.com>