### PR TITLE
Make python shebangs portable (#45)

### DIFF
--- a/OortArgs.py
+++ b/OortArgs.py
@@ -1,9 +1,9 @@
-#!python3
+#!/usr/bin/env python3
 # For Python 3.9.10 or later
 
 # ISC License
 # 
-# Copyright (c) 2022 OHSNAP
+# Copyright (c) 2022-2026 OHSNAP
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above

--- a/OortCommon.py
+++ b/OortCommon.py
@@ -1,9 +1,9 @@
-#!python3
+#!/usr/bin/env python3
 # For Python 3.9.10 or later
 
 # ISC License
 # 
-# Copyright (c) 2022-2025 OHSNAP
+# Copyright (c) 2022-2026 OHSNAP
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above

--- a/autoinstall.py
+++ b/autoinstall.py
@@ -1,9 +1,9 @@
-#!python3
+#!/usr/bin/env python3
 # For Python 3.9.10 or later
 
 # ISC License
 # 
-# Copyright (c) 2022 OHSNAP
+# Copyright (c) 2022-2026 OHSNAP
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above

--- a/createSiteFiles.py
+++ b/createSiteFiles.py
@@ -1,9 +1,9 @@
-#!python3
+#!/usr/bin/env python3
 # For Python 3.9.10 or later
 
 # ISC License
 # 
-# Copyright (c) 2022 OHSNAP
+# Copyright (c) 2022-2026 OHSNAP
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above

--- a/flashInstall.py
+++ b/flashInstall.py
@@ -1,9 +1,9 @@
-#!python3
+#!/usr/bin/env python3
 # For Python 3.9.10 or later
 
 # ISC License
 # 
-# Copyright (c) 2022 OHSNAP
+# Copyright (c) 2022-2026 OHSNAP
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above

--- a/masterDisks.py
+++ b/masterDisks.py
@@ -1,9 +1,9 @@
-#!python3
+#!/usr/bin/env python3
 # For Python 3.9.10 or later
 
 # ISC License
 # 
-# Copyright (c) 2022-2025 OHSNAP
+# Copyright (c) 2022-2026 OHSNAP
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Use `/usr/bin/env` to locate `python3`