### PR TITLE
Overwrite files missing write permission (#50)

### DIFF
--- a/OortCommon.py
+++ b/OortCommon.py
@@ -320,7 +320,11 @@ def copyFileIfNeeded(srcPath, dstPath):
 
     debug("Copy %s -> %s" % (srcPath, dstPath))            
     if needsCopy:
-        shutil.copyfile(srcPath, dstPath)
+        try:
+            shutil.copyfile(srcPath, dstPath)
+        except PermissionError:
+            os.remove(dstPath)
+            shutil.copyfile(srcPath, dstPath)
     else:
         debug("  (Skipping)")
 


### PR DESCRIPTION
When copying a file, detect a `PermissionError` exception and handle it by first deleting the destination file and then retrying the copy.